### PR TITLE
Dockerfile update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ RUN openssl rsa -in keys/token.key -pubout -out keys/token.pub
 RUN npm install -g eslint --loglevel=error
 RUN npm install --loglevel=error
 
-ENTRYPOINT [ "npm", "run", "production" ]
+ENTRYPOINT [ "npm", "run", "start" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ RUN openssl rsa -in keys/token.key -pubout -out keys/token.pub
 RUN npm install -g eslint --loglevel=error
 RUN npm install --loglevel=error
 
-ENTRYPOINT [ "npm", "run", "start" ]
+ENTRYPOINT [ "npm", "start" ]


### PR DESCRIPTION
Now docker image builds cannon in development mode by default. Adda NODE_ENV=production to docker-compose file to run cannon in production mode.