### PR TITLE
Update 2.1.0

### DIFF
--- a/config.js
+++ b/config.js
@@ -13,7 +13,7 @@ config.webapp = {
 }
 
 config.deck = {
-  url: process.env.EVENTDECK_URL || 'https://deck.sinfo.org'
+  url: process.env.CANNON_EVENTDECK_URL || 'https://deck.sinfo.org'
 }
 
 config.upload = {
@@ -22,6 +22,15 @@ config.upload = {
   cvsZipPath: process.env.CANNON_UPLOAD_CVSZIP_PATH || join(__dirname, `/CVS.zip`),
   cvsZipAge: process.env.CANNON_UPLOAD_CVSZIP_AGE || 3600 * 1000, // 1 hour in miliseconds
   cvsLinkPath: join(__dirname, `/CVSlink.zip`)
+}
+
+config.aws = {
+  storageRegion: process.env.CANNON_AWS_STORAGE_REGION || 'AWS_STORAGE_REGION',
+  storageDomain: process.env.CANNON_AWS_STORAGE_DOMAIN || 'AWS_STORAGE_DOMAIN',
+  storageKey: process.env.CANNON_AWS_STORAGE_KEY || 'AWS_STORAGE_KEY',
+  storageSecret: process.env.CANNON_AWS_STORAGE_SECRET || 'AWS_STORAGE_SECRET',
+  storageName: process.env.CANNON_AWS_STORAGE_NAME || 'AWS_STORAGE_NAME',
+  storageTest: process.env.CANNON_AWS_STORAGE_TEST || '/cannon/test/'
 }
 
 config.mongo = {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "homepage": "https://github.com/sinfo/cannon-api",
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.272.0",
     "@hapi/basic": "^6.0.0",
     "@hapi/boom": "^9.1.4",
     "@hapi/hapi": "^20.2.1",
@@ -40,6 +41,7 @@
     "adm-zip": "^0.5.9",
     "async": "^3.2.3",
     "axios": "^0.26.0",
+    "aws-sdk": "^2.814.0",
     "bunyan": "^1.8.15",
     "esprima": "^4.0.1",
     "good": "^2.3.0",
@@ -59,7 +61,6 @@
     "qr-image": "~3.2.0",
     "qs": "^6.10.3",
     "request": "^2.44.0",
-    "slug": "~5.3.0",
     "underscore": "^1.13.2",
     "urlencode": "^1.1.0",
     "uuid": "^8.3.2"

--- a/server/plugins/aws.js
+++ b/server/plugins/aws.js
@@ -1,0 +1,58 @@
+const aws = require('@aws-sdk/client-s3')
+const path = require('path')
+const config = require(path.join(__dirname, '..', '..', 'config'))
+const mime = require('mime-types')
+const log = require('../helpers/logger')
+
+const s3Client = new aws.S3Client({
+  endpoint: `https://${config.aws.storageRegion}.${config.aws.storageDomain}`,
+  forcePathStyle: false,
+  region: config.aws.storageRegion,
+  credentials: {
+    accessKeyId: config.aws.storageKey,
+    secretAccessKey: config.aws.storageSecret
+  }
+})
+
+module.exports.download = async (path, filename) => {
+  const params = {
+    Bucket: config.aws.storageName,
+    Key: path + filename
+  }
+
+  try {
+    await s3Client.send(new aws.GetObjectCommand(params))
+  } catch(err) {
+    log.error({ error: err })
+  }
+}
+
+module.exports.upload = async (path, buffer, filename, isPublic) => {
+  const params = {
+    Bucket: config.aws.storageName,
+    Key: path + filename,
+    Body: buffer,
+    ACL: isPublic !== undefined && isPublic ? 'public-read' : 'authenticated-read',
+    ContentType: mime.lookup(filename)
+  }
+
+  try {
+    await s3Client.send(new aws.PutObjectCommand(params))
+    return `https://${config.aws.storageName}.${config.aws.storageRegion}.${config.aws.storageDomain}/${path}${filename}`
+  } catch(err) {
+    log.error({ error: err })
+  }
+}
+
+module.exports.delete = async (path, filename) => {
+  const params = {
+    Bucket: config.aws.storageName,
+    Key: path + filename
+  }
+
+  try {
+    await s3Client.send(new aws.DeleteObjectCommand(params))
+  } catch(err) {
+    log.error({ error: err })
+  }
+}

--- a/server/plugins/index.js
+++ b/server/plugins/index.js
@@ -1,0 +1,1 @@
+require('./aws')

--- a/server/resources/deck.js
+++ b/server/resources/deck.js
@@ -1,0 +1,78 @@
+const server = require('../').hapi
+const axios = require('axios').default
+const path = require('path')
+const log = require('../helpers/logger')
+const config = require(path.join(__dirname, '..', '..', 'config'))
+
+
+server.method('deck.getLatestEdition', getLatestEdition, {})
+server.method('deck.getPreviousEdition', getPreviousEdition, {})
+server.method('deck.getEvents', getEvents, {})
+server.method('deck.getCompanies', getCompanies, {})
+server.method('deck.getCompany', getCompany, {})
+server.method('deck.getMembers', getMembers, {})
+server.method('deck.getSessions', getSessions, {})
+server.method('deck.getSession', getSession, {})
+server.method('deck.getSpeakers', getSpeakers, {})
+server.method('deck.getSpeaker', getSpeaker, {})
+
+const DECK_API_URL = `${config.deck.url}/api`
+
+async function getLatestEdition() {
+  const event = await axios.get(`${DECK_API_URL}/events?sort=-date&limit=1`, { json: true })
+  return event.data[0]
+}
+
+async function getEvents() {
+  const events = await axios.get(`${DECK_API_URL}/events?sort=-date`, { json: true })
+  return events.data
+}
+
+async function getPreviousEdition() {
+  const event = await axios.get(`${DECK_API_URL}/events?sort=-date&limit=1&skip=1`, { json: true })
+  return event.data[0]
+}
+
+async function getCompanies(edition) {
+  const companies = await axios.get(`${DECK_API_URL}/companies?event=${edition}`, { json: true })
+  
+
+  return companies.data.map(company => {
+    return {
+      id: company.id,
+      name: company.name,
+      advertisementLvl: company.advertisementLvl,
+      img: company.img
+    }
+  })
+}
+
+async function getCompany(companyId) {
+  const company = await axios.get(`${DECK_API_URL}/companies/${companyId}`, { json: true })
+  return company.data
+}
+
+async function getMembers(edition) {
+  const members = await axios.get(`${DECK_API_URL}/members?sort=name&event=${edition}&participations=true`, { json: true })
+  return members.data
+}
+
+async function getSessions(edition) {
+  const sessions = await axios.get(`${DECK_API_URL}/sessions?sort=date&event=${edition}`)
+  return sessions.data
+}
+
+async function getSession(sessionId) {
+  const session = await axios.get(`${DECK_API_URL}/sessions/${sessionId}`)
+  return session.data
+} 
+
+async function getSpeakers(edition) {
+  const speakers = await axios.get(`${DECK_API_URL}/speakers?sort=name&event=${edition}&participations=true`)
+  return speakers.data
+}
+
+async function getSpeaker(speakerId) {
+  const speaker = await axios.get(`${DECK_API_URL}/speakers/${speakerId}`)
+  return speaker.data
+} 

--- a/server/resources/index.js
+++ b/server/resources/index.js
@@ -1,5 +1,6 @@
 require('./achievement')
 require('./auth')
+require('./deck')
 require('./email')
 require('./file')
 require('./redeem')

--- a/server/resources/user.js
+++ b/server/resources/user.js
@@ -193,14 +193,14 @@ async function remove (filter) {
 
 }
 
-async function sign (attendeeId, companyId, payload, cb) {
+async function sign (attendeeId, companyId, day, editionId) {
   // todo verify
   const filter = {
     id: attendeeId,
     signatures: {
       $elemMatch: {
-        day: payload.day,
-        edition: payload.editionId
+        day: day,
+        edition: editionId
       }
     }
   }
@@ -214,7 +214,7 @@ async function sign (attendeeId, companyId, payload, cb) {
   }
 
   let user = await User.findOneAndUpdate(filter, update, {new: true}).catch((err) => {
-    log.error({ err: err, attendeeId: attendeeId, companyId: companyId, day: payload.day, editionId: payload.editionId }, 'Error signing user')
+    log.error({ err: err, attendeeId: attendeeId, companyId: companyId, day: day, editionId: editionId }, 'Error signing user')
    throw Boom.boomify(err)
   })
   
@@ -248,14 +248,14 @@ async function sign (attendeeId, companyId, payload, cb) {
   }
 }
 
-async function redeemCard (attendeeId, payload) {
+async function redeemCard (attendeeId, day, editionId) {
   // todo verify
   const filter = {
     id: attendeeId,
     signatures: {
       $elemMatch: {
-        day: payload.day,
-        edition: payload.editionId
+        day: day,
+        edition: editionId
       }
     }
   }
@@ -268,18 +268,18 @@ async function redeemCard (attendeeId, payload) {
 
   // this should not be here
   let user = await User.findOne(filter).catch((err) => {
-    log.error({ err: err, attendeeId: attendeeId, day: payload.day, editionId: payload.editionId }, 'Error getting user')
+    log.error({ err: err, attendeeId: attendeeId, day: day, editionId: editionId }, 'Error getting user')
     throw Boom.internal()
   })
 
   if (!user) {
     // day,event combination entry did not exist
-    log.error({ attendeeId: attendeeId, day: payload.day, editionId: payload.editionId }, 'Error getting user')
+    log.error({ attendeeId: attendeeId, day: day, editionId: editionId }, 'Error getting user')
     throw Boom.notFound()
   }
 
   // this should not be hardcoded
-  let signatures = user.signatures.filter(s => s.day === payload.day && s.edition === payload.editionId)
+  let signatures = user.signatures.filter(s => s.day === day && s.edition === editionId)
   if (signatures || signatures.length == 0){
     log.error({ user: user }, 'not enough signatures to validate card')
     throw Boom.badData({ user: user }, 'not enough signatures to validate card')
@@ -298,7 +298,7 @@ async function redeemCard (attendeeId, payload) {
   user = await User.findOneAndUpdate(filter, update,{new: true})
   if (!user) {
     // day,event combination entry did not exist
-    log.error({ err: err, attendeeId: attendeeId, day: payload.day, editionId: payload.editionId }, 'Error signing user')
+    log.error({ err: err, attendeeId: attendeeId, day: day, editionId: editionId }, 'Error signing user')
     throw Boom.notFound()
   }
   return user

--- a/server/routes/achievement/handlers.js
+++ b/server/routes/achievement/handlers.js
@@ -2,6 +2,7 @@ const Joi = require('joi')
 const render = require('../../views/achievement')
 const log = require('../../helpers/logger')
 const Boom = require('@hapi/boom')
+const configUpload = require('../../../config').upload
 
 exports = module.exports
 
@@ -12,13 +13,20 @@ exports.create = {
       strategies: ['default'],
       scope: ['admin']
     },
+    payload: {
+      output: 'stream',
+      multipart: true,
+      parse: true,
+      allow: 'multipart/form-data',
+      maxBytes: configUpload.maxSize
+    },
     validate: {
       payload: Joi.object({
         id: Joi.string().description('Id of the achievement'),
         name: Joi.string().required().description('Name of the achievement'),
         event: Joi.string().default('22').description('Event the achievement is associated to'),
         session: Joi.string().description('Id of a session associated to this achievement'),
-        img: Joi.string().description('Image of the achievement'),
+        img: Joi.any().meta({ swaggerType: 'file' }).description('Image of the achievement'),
         description: Joi.string().description('Description of the achievement'),
         category: Joi.string().description('Category of the achievement'),
         instructions: Joi.string().description('Instructions on how to get the achievement'),

--- a/server/routes/company-endpoint/handlers.js
+++ b/server/routes/company-endpoint/handlers.js
@@ -1,5 +1,6 @@
 const Joi = require('joi')
 const render = require('../../views/endpoint')
+const renderCompanies = require('../../views/company')
 const log = require('../../helpers/logger')
 const Boom = require('@hapi/boom')
 

--- a/server/routes/deck/handlers.js
+++ b/server/routes/deck/handlers.js
@@ -1,0 +1,187 @@
+const Joi = require('joi')
+const renderCompanies = require('../../views/company')
+const renderMembers = require('../../views/member')
+const renderSessions = require('../../views/session')
+const renderSpeakers = require('../../views/speaker')
+const renderEvents = require('../../views/event')
+const log = require('../../helpers/logger')
+const Boom = require('@hapi/boom')
+
+exports = module.exports
+
+exports.getAll = {
+    options: {
+        tags: ['api', 'company'],
+        description: 'Gets all companies for the latest edition'
+    },
+    handler: async (request, h) => {
+        try {
+            const latestEdition = await request.server.methods.deck.getLatestEdition()
+            const companies = await request.server.methods.deck.getCompanies(latestEdition.id)
+            return h.response(renderCompanies(companies))
+        } catch (err) {
+            log.error({ err: err}, 'error getting company')
+            throw Boom.internal()
+        }
+    }
+}
+
+exports.getCompany = {
+    options: {
+        tags: ['api', 'company'],
+        validate: {
+            params: Joi.object({
+            companyId: Joi.string().required().description('Id of the company')
+            })
+        },
+        description: 'Gets specific company'
+    },
+    handler: async (request, h) => {
+        try {
+            const company = await request.server.methods.deck.getCompany(request.params.companyId)
+            return h.response(renderCompanies(company))
+        } catch (err) {
+            log.error({ err: err}, 'error getting company')
+            throw Boom.internal()
+        }
+    }
+}
+
+exports.getMembers = {
+    options: {
+      tags: ['api', 'member'],
+      description: 'Get members'
+    },
+    handler: async (request, h) => {
+      try {
+        const latestEdition = await request.server.methods.deck.getLatestEdition()
+        const members = await request.server.methods.deck.getMembers(latestEdition.id)
+        return h.response(renderMembers(members))
+      } catch(err) {
+        log.error({ error: err })
+        throw Boom.boomify(err)
+      }
+    }
+}
+
+exports.getEvents = {
+    options: {
+        tags: ['api', 'event'],
+        description: 'Get all SINFO events'
+    },
+    handler: async (request, h) => {
+        try {
+            const events = await request.server.methods.deck.getEvents()
+            return h.response(renderEvents(events))
+        } catch(err) {
+            log.error({ error: err })
+            throw Boom.boomify(err)
+        }
+    }
+}
+
+exports.getLatestEvent = {
+    options: {
+        tags: ['api', 'event'],
+        description: 'Get the current SINFO event'
+    },
+    handler: async (request, h) => {
+        //try {
+            const event = await request.server.methods.deck.getLatestEdition()
+            return h.response(renderEvents(event))
+        /*} catch(err) {
+            log.error({ error: err })
+            throw Boom.boomify(err)
+        }*/
+    }
+}
+
+exports.getSessions = {
+    options: {
+        tags: ['api', 'session'],
+        description: 'Get all sessions'
+    },
+    handler: async (request, h) => {
+        try {
+            const latestEdition = await request.server.methods.deck.getLatestEdition()
+            const sessions = await request.server.methods.deck.getSessions(latestEdition.id)
+            return h.response(renderSessions(sessions))
+        } catch(err) {
+            log.error({ error: err })
+            throw Boom.boomify(err)
+        }
+    }
+}
+
+exports.getSession = {
+    options: {
+        tags: ['api', 'session'],
+        description: 'Get session for a specific event',
+        validate: {
+            params: Joi.object({
+                sessionId: Joi.string().description('id of the session')
+            })
+        }
+    },
+    handler: async (request, h) => {
+        try {
+            const session = await request.server.methods.deck.getSession(request.params.sessionId)
+            return h.response(renderSessions(session))
+        } catch(err) {
+            log.error({ error: err })
+            throw Boom.boomify(err)
+        }
+    }
+}
+
+
+exports.getSpeakers = {
+    options: {
+        tags: ['api', 'speaker'],
+        description: 'Get speakers for the current or previous edition'
+    },
+    handler: async (request, h) => {
+        try {
+            let previousEdition = false
+            let edition = await request.server.methods.deck.getLatestEdition()
+            let speakers
+            
+            speakers = await request.server.methods.deck.getSpeakers(edition.id)
+            if (speakers.length === 0) {
+                edition = await request.server.methods.deck.getPreviousEdition()
+                speakers = await request.server.methods.deck.getSpeakers(edition.id)
+                previousEdition = true
+            }
+
+            return h.response({
+                eventId: edition,
+                speakers: renderSpeakers(speakers),
+                previousEdition: previousEdition
+            })
+        } catch(err) {
+            log.error({ error: err })
+            throw Boom.boomify(err)
+        }
+    }
+}
+
+exports.getSpeaker = {
+    options: {
+        tags: ['api', 'speaker'],
+        description: 'Get speaker for the current or previous edition',
+        validate: {
+            params: Joi.object({
+                speakerId: Joi.string().description('id of the speaker')
+            })
+        }
+    },
+    handler: async (request, h) => {
+        try {
+            const speaker = await request.server.methods.deck.getSpeaker(request.params.speakerId)
+            return h.response(renderSpeakers(speaker))
+        } catch(err) {
+            log.error({ error: err })
+            throw Boom.boomify(err)
+        }
+    }
+}

--- a/server/routes/deck/index.js
+++ b/server/routes/deck/index.js
@@ -1,0 +1,65 @@
+const server = require('../../').hapi
+const handlers = require('./handlers')
+
+server.route({
+    method: 'GET',
+    path: '/company',
+    options: handlers.getAll.options,
+    handler: handlers.getAll.handler
+})
+
+server.route({
+    method: 'GET',
+    path: '/company/{companyId}',
+    options: handlers.getCompany.options,
+    handler: handlers.getCompany.handler
+})
+
+server.route({
+    method: 'GET',
+    path: '/member',
+    options: handlers.getMembers.options,
+    handler: handlers.getMembers.handler
+})
+
+server.route({
+    method: 'GET',
+    path: '/event',
+    options: handlers.getEvents.options,
+    handler: handlers.getEvents.handler
+})
+
+server.route({
+    method: 'GET',
+    path: '/event/latest',
+    options: handlers.getLatestEvent.options,
+    handler: handlers.getLatestEvent.handler
+})
+
+server.route({
+    method: 'GET',
+    path: '/session',
+    options: handlers.getSessions.options,
+    handler: handlers.getSessions.handler
+})
+
+server.route({
+    method: 'GET',
+    path: '/session/${sessionId}',
+    options: handlers.getSession.options,
+    handler: handlers.getSession.handler
+})
+
+server.route({
+    method: 'GET',
+    path: '/speaker',
+    options: handlers.getSpeakers.options,
+    handler: handlers.getSpeakers.handler
+})
+
+server.route({
+    method: 'GET',
+    path: '/speaker/{speakerId}',
+    options: handlers.getSpeaker.options,
+    handler: handlers.getSpeaker.handler
+})

--- a/server/routes/file/handlers.js
+++ b/server/routes/file/handlers.js
@@ -1,7 +1,6 @@
 const Joi = require('joi')
 const render = require('../../views/file')
 const configUpload = require('../../../config').upload
-const server = require('../../').hapi
 const log = require('../../helpers/logger')
 const Boom = require('@hapi/boom')
 

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -1,4 +1,5 @@
 require('./achievement')
+require('./deck')
 require('./file')
 require('./redeem')
 require('./auth')

--- a/server/routes/sign/handlers.js
+++ b/server/routes/sign/handlers.js
@@ -16,19 +16,17 @@ exports.create = {
       params: Joi.object({
         companyId: Joi.string().required().description('Id of the company we are linking from'),
         attendeeId: Joi.string().required().description('Id of the attendee')
-      }),
-      payload: Joi.object({
-        editionId: Joi.string().required().description('Id of the edition'),
-        day: Joi.string().required().description('Day the company is signing the users card')
       })
     },
     description: 'Creates a new signature'
   },
   handler: async function (request, h) {
     try {
-      await request.server.methods.link.checkCompany(request.auth.credentials.user.id, request.params.companyId, request.payload.editionId)
+      const edition = await request.server.methods.deck.getLatestEdition()
+      const day = new Date().getDate().toString()
+      await request.server.methods.link.checkCompany(request.auth.credentials.user.id, request.params.companyId, edition.id)
       await request.server.methods.achievement.addUserToStandAchievement(request.params.companyId, request.params.attendeeId)
-      let user = await request.server.methods.user.sign(request.params.attendeeId, request.params.companyId, request.payload)
+      let user = await request.server.methods.user.sign(request.params.attendeeId, request.params.companyId, day, edition.id)
       await request.server.methods.achievement.checkUserStandDay(request.params.attendeeId)
       return h.response(render(user, request.auth.credentials && request.auth.credentials.user))
     } catch (err) {
@@ -49,16 +47,14 @@ exports.speed = {
       params: Joi.object({
         companyId: Joi.string().required().description('Id of the company '),
         attendeeId: Joi.string().required().description('Id of the attendee')
-      }),
-      payload: Joi.object({
-        editionId: Joi.string().required().description('Id of the edition')
       })
     },
     description: 'Creates a new signature for speed dates'
   },
   handler: async function (request, h) {
     try {
-      await request.server.methods.link.checkCompany(request.auth.credentials.user.id, request.params.companyId, request.payload.editionId)
+      const edition = await request.server.methods.deck.getLatestEdition()
+      await request.server.methods.link.checkCompany(request.auth.credentials.user.id, request.params.companyId, edition.id)
       let happyHours = await request.server.methods.happyHour.get()
       let achievement = await request.server.methods.achievement.addUserToSpeedDateAchievement(request.params.companyId, request.params.attendeeId, happyHours)
       return h.response(achievement)

--- a/server/routes/user/handlers.js
+++ b/server/routes/user/handlers.js
@@ -2,8 +2,6 @@ const Joi = require('joi')
 const render = require('../../views/user')
 const log = require('../../helpers/logger')
 const Boom = require('@hapi/boom')
-const dupKeyParser = require('../../helpers/dupKeyParser')
-
 
 exports = module.exports
 
@@ -373,17 +371,15 @@ exports.redeemCard = {
     validate: {
       params: Joi.object({
         id: Joi.string().required().description('Id of the user we want to redeem the card from')
-      }),
-      payload: Joi.object({
-        day: Joi.string().required().description('ISO Date of the day you are redeeming the card from'),
-        editionId: Joi.string().required().description('Id of the current edition')
       })
     },
     description: 'Clears Users Card Signatures for the day'
   },
   handler: async (request, h) => {
     try{
-      let user = await request.server.methods.user.redeemCard(request.params.id, request.payload)
+      const edition = await request.server.methods.deck.getLatestEdition()
+      const day = new Date().getDate().toString()
+      let user = await request.server.methods.user.redeemCard(request.params.id, day, edition.id)
       return h.response(render(user, request.auth.credentials && request.auth.credentials.user))
     }catch(err){
       log.error({err: err}, 'error redeeming card')

--- a/server/test/achievement.js
+++ b/server/test/achievement.js
@@ -1,6 +1,6 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
-const slug = require('slug')
+const uuid = require('uuid')
 
 const server = require('../').hapi
 
@@ -41,7 +41,7 @@ const achievementA = {
     to: new Date(new Date().getTime() + (1000 * 60 * 60)) // 1 h
   }
 }
-const achievementId = slug(achievementA.name)
+const achievementId = uuid.v4()
 
 const changesToA = {
   name: 'WENT TO SINFO XXIII'

--- a/server/test/user.js
+++ b/server/test/user.js
@@ -1,6 +1,6 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
-const slug = require('slug')
+const uuid = require('uuid')
 
 const server = require('../').hapi
 
@@ -65,7 +65,7 @@ const achievementA = {
     to: new Date(new Date().getTime() + (1000 * 60 * 60)) // 1 h
   }
 }
-const achievementId = slug(achievementA.name)
+const achievementId = uuid.v4()
 
 const changesToA = {
   name: 'John Doe Doe'

--- a/server/views/company.js
+++ b/server/views/company.js
@@ -1,0 +1,17 @@
+module.exports = function render (content) {
+  if (content instanceof Array) {
+    return content.map(renderObject)
+  }
+
+  return renderObject(content)
+}
+  
+function renderObject (model) {
+  return {
+      id: model.id,
+      name: model.name,
+      advertisementLvl: model.advertisementLvl,
+      img: model.img
+  }
+}
+  

--- a/server/views/event.js
+++ b/server/views/event.js
@@ -1,0 +1,22 @@
+module.exports = function render (content) {
+    if (content instanceof Array) {
+      return content.map(renderObject)
+    }
+  
+    return renderObject(content)
+  }
+    
+  function renderObject (model) {
+    return {
+        id: model.id,
+        name: model.name,
+        kind: model.kind,
+        date: model.date,
+        updated: model.updated,
+        duration: model.duration,
+        begin: model.begin,
+        end: model.end,
+        isOcurring: model.isOcurring
+    }
+  }
+    

--- a/server/views/member.js
+++ b/server/views/member.js
@@ -1,0 +1,20 @@
+module.exports = function render (content) {
+    if (content instanceof Array) {
+      return content.map(renderObject)
+    }
+  
+    return renderObject(content)
+  }
+  
+  function renderObject (model) {
+    return {
+        id: model.id,
+        name: model.name,
+        img: model.img,
+        github: model.github,
+        facebook: model.facebook,
+        mail: model.mail,
+        twitter: model.witter
+    }
+  }
+  

--- a/server/views/session.js
+++ b/server/views/session.js
@@ -1,0 +1,27 @@
+module.exports = function render (content) {
+    if (content instanceof Array) {
+      return content.map(renderObject)
+    }
+  
+    return renderObject(content)
+  }
+    
+  function renderObject (model) {
+    return {
+        id: model.id,
+        name: model.name,
+        kind: model.kind,
+        img: model.img,
+        place: model.place,
+        description: model.description,
+        speakers: model.speakers,
+        companies: model.companies,
+        date: model.date,
+        duration: model.duration,
+        updated: model.updated,
+        event: model.event,
+        tickets: model.tickets,
+        surveyNeeded: model.surveyNeeded
+    }
+  }
+    

--- a/server/views/speaker.js
+++ b/server/views/speaker.js
@@ -1,0 +1,19 @@
+module.exports = function render (content) {
+    if (content instanceof Array) {
+      return content.map(renderObject)
+    }
+  
+    return renderObject(content)
+  }
+    
+  function renderObject (model) {
+    return {
+        id: model.id,
+        name: model.name,
+        description: model.description,
+        title: model.title,
+        img: model.img,
+        updated: model.updated
+    }
+  }
+    


### PR DESCRIPTION
* feat: Add deck plugin

* feat: Add aws-sdk package

* feat: Add AWS environment variables to config

* feat: Update config

* refact: Use methods for achievements

* refact: Join achievement server methods

* refact: Join achievement server methods

* refact: Change endpoint so that it works with achievements frontend

* refact: Use uuid instead of slug

* feat: Store achievement image on Digital Ocean

* refact: Change tests to use uuid instead of slug

* fix: Change config path

* fix: Change test path

* feat: Log errors from AWS

* refact: Change achievement file name logic

* feat: Add authorized content type

* fix: Remove unecessary requirement

* feat: Import plugins

* refact: Use different AWS library

* fix: Achievement validity can be null

* feat: Add handlers to proxy deck requests

* feat: Add endpoints to proxy deck requests

* refact: Return response data instead of response

* fix: Add deck requirement

* fix: Add deck dependency

* feat: Add routes for members

* feat: Add views for companies and members

* fix: Only get members from latest edition

* refact: Change EVENTDECK_URL environment variable name

* feat: Implement methods for sessions, speakers and events

* feat: Implement views for companies, events, sessions and speakers

* refact: Remove endpoints and handlers from user and company-dpoint

* feat: Implement handlers for Deck methods

* refact: Fetch event id from Deck

* fix: Always validate date and edition id in cannon

* feat: Add aws package to package.json