### PR TITLE
feat: Accept access token for authentication instead of code

### DIFF
--- a/server/helpers/fenix.js
+++ b/server/helpers/fenix.js
@@ -2,50 +2,13 @@ const server = require('../').hapi
 const log = require('./logger')
 const fenixConfig = require('../../config').fenix
 const axios = require('axios').default
-const qs = require('qs')
 
 const fenix = {}
 
-fenix.getToken = async function(code) {
-  const queryParams = {
-    client_id: fenixConfig.clientId,
-    client_secret: fenixConfig.clientSecret,
-    redirect_uri: fenixConfig.redirectUri,
-    code: code,
-    grant_type: 'authorization_code'
-  }
+fenix.getFenixUser = async (accessToken) => {
+  const url = fenixConfig.url + 'person?access_token=' + encodeURIComponent(accessToken)
 
-  const options = {
-    url: fenixConfig.oauthUrl + 'access_token?'+ qs.stringify(queryParams),
-    headers: {
-      'Content-Type': 'application/x-www-form-urlencoded'
-    },
-  }
-
-  let response = await axios.post(options.url, options.headers, { json: true }).catch((error) => {
-    log.warn({
-      error,
-      fenixConfig: fenixConfig,
-      where: 'getToken'
-    })
-
-    throw error
-  })
-
-  if(response.status !== 200){
-    throw new Error('[Fenix-Auth] Invalid token')
-  }  
-
-  log.info(response.data)
-  return response.data.access_token
-}
-
-fenix.getFenixUser = async function(token) {
-  const options = {
-    url: fenixConfig.url + 'person?access_token=' + encodeURIComponent(token)
-  }
-
-  let response = await axios.get(options.url, null, { json: true }).catch((error) => {
+  let response = await axios.get(url, null, { json: true }).catch((error) => {
     log.warn({
       error,
       where: 'getFenixUser'

--- a/server/helpers/microsoft.js
+++ b/server/helpers/microsoft.js
@@ -2,7 +2,6 @@ const server = require('../').hapi
 const axios = require('axios').default
 const log = require('./logger')
 const microsoftConfig = require('../../config').microsoft
-const qs = require('qs')
 
 const microsoft = {}
 
@@ -31,39 +30,16 @@ async function fetch(endpoint, accessToken) {
     }
 }
 
-microsoft.getToken = async (code) => {
-    const options = {
-        json: false,
-        headers: {
-            'Content-Type': 'application/x-www-form-urlencoded'
-        }
-    }
-
-    const params = {
-        client_id: microsoftConfig.clientId,
-        scope: 'user.read',
-        code: code,
-        redirect_uri: microsoftConfig.redirectUri,
-        grant_type: 'authorization_code',
-        client_secret: microsoftConfig.clientSecret
-    }
-
-    const response = await axios.post(`${microsoftConfig.authority}/oauth2/v2.0/token`, qs.stringify(params), options)
-        .catch((error) => log.error(error))
-
-    return response.data.access_token
-}
-
 microsoft.getEmail = (microsoftUser) => {
     return microsoftUser.mail ? microsoftUser.mail : microsoftUser.userPrincipalName;
 }
 
-microsoft.getProfilePicture = async (token) => {
-    return fetch('/v1.0/me/photo/$value', token)
+microsoft.getProfilePicture = async (accessToken) => {
+    return fetch('/v1.0/me/photo/$value', accessToken)
 }
 
-microsoft.getMicrosoftUser = async (token) => {
-    return fetch('/v1.0/me', token)
+microsoft.getMicrosoftUser = async (accessToken) => {
+    return fetch('/v1.0/me', accessToken)
 }
 
 microsoft.getUser = async (microsoftUser) => {

--- a/server/routes/auth/handlers.js
+++ b/server/routes/auth/handlers.js
@@ -45,15 +45,14 @@ exports.google = {
     },
     validate: {
       payload: Joi.object({
-        id: Joi.string().required().description('google id of the member'),
-        token: Joi.string().required().description('google token of the member')
+        accessToken: Joi.string().required().description('google access token of the member')
       })
     },
     description: 'Google login'
   },
   handler: async function (request, h) {
     try {
-      let member = await request.server.methods.auth.google(request.payload.id, request.payload.token);
+      let member = await request.server.methods.auth.google(request.payload.accessToken);
       return h.response(render(member))
     } catch (err) {
       if (err.code === 11000) {
@@ -76,14 +75,14 @@ exports.microsoft = {
     },
     validate: {
       payload: Joi.object({
-        code: Joi.string().required().description('microsoft code of the member')
+        accessToken: Joi.string().required().description('microsoft access token of the member')
       })
     },
     description: 'Microsoft login'
   },
   handler: async function (request, h) {
     try {
-      let member = await request.server.methods.auth.microsoft(request.payload.code)
+      let member = await request.server.methods.auth.microsoft(request.payload.accessToken)
       return h.response(render(member))
     } catch (err) {
       if (err.code === 11000) {
@@ -107,14 +106,14 @@ exports.fenix = {
     },
     validate: {
       payload: Joi.object({
-        code: Joi.string().required().description('fenix code of the member')
+        accessToken: Joi.string().required().description('fenix access token of the member')
       })
     },
     description: 'Fenix login'
   },
   handler: async function (request, h) {
     try {
-      let member = await request.server.methods.auth.fenix(request.payload.code);
+      let member = await request.server.methods.auth.fenix(request.payload.accessToken);
       return h.response(render(member))
     } catch (err) {
       if (err.code === 11000) {
@@ -137,14 +136,14 @@ exports.linkedin = {
     },
     validate: {
       payload: Joi.object({
-        code: Joi.string().required().description('Linkedin code of the member')
+        accessToken: Joi.string().required().description('linkedin access token of the member')
       })
     },
     description: 'Linkedin login'
   },
   handler: async function (request, h) {
     try {
-      let member = await request.server.methods.auth.linkedin(request.payload.code);
+      let member = await request.server.methods.auth.linkedin(request.payload.accessToken);
       return h.response(render(member))
     } catch (err) {
       if (err.code === 11000) {


### PR DESCRIPTION
Summary of changes:

- `routes/auth/handlers.js`: Change LinkedIn, Fenix, Google and Microsoft's authentication handlers to accept only access token as payload.
- `resources/auth/js`: Remove function calls to exchange code for access token + Add try/catch to googleAuth() and linkedinAuth() + Some formatting/naming changes (for consistency).
- `helpers/google.js`: Remove verifyToken() + Implement getGoogleUser() + Remove unused imports
- `helpers/*.js`: Remove getToken() (we get access token directly from frontend now) + Remove unused imports/variables + Some formatting/naming changes