### PR TITLE
Remove optional auth mode from achievement code endpoints

### DIFF
--- a/server/routes/achievement/handlers.js
+++ b/server/routes/achievement/handlers.js
@@ -388,8 +388,7 @@ exports.listWithCode = {
     tags: ['api', 'achievement'],
     auth: {
       strategies: ['default'],
-      scope: ['team', 'admin'],
-      mode: 'try'
+      scope: ['team', 'admin']
     },
     validate: {
       query: Joi.object({
@@ -415,8 +414,7 @@ exports.getWithCode = {
     tags: ['api', 'achievement'],
     auth: {
       strategies: ['default'],
-      scope: ['team', 'admin'],
-      mode: 'try'
+      scope: ['team', 'admin']
     },
     validate: {
       query: Joi.object({


### PR DESCRIPTION
This PR fixes a security issue caused by using mode: try in achievement routes protected by team/admin scope.

With mode: authentication failures can still pass through as unauthenticated requests, which makes that anyone can  do the request and have the codes of each achievement.

:mage: 